### PR TITLE
feat(hooks): enhance useRenderState with options object for rendering states

### DIFF
--- a/src/hooks/use-render-state.interface.ts
+++ b/src/hooks/use-render-state.interface.ts
@@ -92,10 +92,6 @@ export interface RenderOptions<Data, Error> {
 export interface Render<Data, Error> {
   (renderSuccess?: RenderSuccess<Data, Error>): ReactNode;
   (
-    renderSuccess?: RenderSuccess<Data, Error>,
-    renderLoading?: RenderLoading<Data, Error>,
-  ): ReactNode;
-  (
     renderIdle?: RenderIdle<Data, Error>,
     renderLoading?: RenderLoading<Data, Error>,
     renderSuccess?: RenderSuccess<Data, Error>,

--- a/src/hooks/use-render-state.interface.ts
+++ b/src/hooks/use-render-state.interface.ts
@@ -80,10 +80,10 @@ export interface RenderSuccess<Data, Error> {
  * RenderOptions
  */
 export interface RenderOptions<Data, Error> {
-  onIdle?: RenderIdle<Data, Error>;
-  onLoading?: RenderLoading<Data, Error>;
-  onSuccess?: RenderSuccess<Data, Error>;
-  onError?: RenderError<Data, Error>;
+  renderIdle?: RenderIdle<Data, Error>;
+  renderLoading?: RenderLoading<Data, Error>;
+  renderSuccess?: RenderSuccess<Data, Error>;
+  renderError?: RenderError<Data, Error>;
 }
 
 /**

--- a/src/hooks/use-render-state.interface.ts
+++ b/src/hooks/use-render-state.interface.ts
@@ -77,14 +77,29 @@ export interface RenderSuccess<Data, Error> {
 }
 
 /**
+ * RenderOptions
+ */
+export interface RenderOptions<Data, Error> {
+  onIdle?: RenderIdle<Data, Error>;
+  onLoading?: RenderLoading<Data, Error>;
+  onSuccess?: RenderSuccess<Data, Error>;
+  onError?: RenderError<Data, Error>;
+}
+
+/**
  * Render
  */
 export interface Render<Data, Error> {
   (renderSuccess?: RenderSuccess<Data, Error>): ReactNode;
+  (
+    renderSuccess?: RenderSuccess<Data, Error>,
+    renderLoading?: RenderLoading<Data, Error>,
+  ): ReactNode;
   (
     renderIdle?: RenderIdle<Data, Error>,
     renderLoading?: RenderLoading<Data, Error>,
     renderSuccess?: RenderSuccess<Data, Error>,
     renderError?: RenderError<Data, Error>,
   ): ReactNode;
+  (renderOptions: RenderOptions<Data, Error>): ReactNode;
 }

--- a/src/hooks/use-render-state.test.tsx
+++ b/src/hooks/use-render-state.test.tsx
@@ -441,14 +441,16 @@ describe("useRenderState", () => {
 });
 
 describe("useRenderState with render options object", () => {
-  it("should render idle state with onIdle option", async () => {
+  it("should render idle state with renderIdle option", async () => {
     const TestComponent = () => {
       const [renderComponent] = useRenderState<number, Error>();
       return renderComponent({
-        onIdle: () => <div data-testid="status">render idle</div>,
-        onLoading: () => <div data-testid="status">render loading</div>,
-        onSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderIdle: () => <div data-testid="status">render idle</div>,
+        renderLoading: () => <div data-testid="status">render loading</div>,
+        renderSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       });
     };
 
@@ -460,7 +462,7 @@ describe("useRenderState with render options object", () => {
     unmount();
   });
 
-  it("should render loading state with onLoading option", async () => {
+  it("should render loading state with renderLoading option", async () => {
     const TestComponent = () => {
       const [renderComponent, handleData] = useRenderState<number, Error>();
 
@@ -472,10 +474,12 @@ describe("useRenderState with render options object", () => {
       }, [handleData]);
 
       return renderComponent({
-        onIdle: () => <div data-testid="status">render idle</div>,
-        onLoading: () => <div data-testid="status">render loading</div>,
-        onSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderIdle: () => <div data-testid="status">render idle</div>,
+        renderLoading: () => <div data-testid="status">render loading</div>,
+        renderSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       });
     };
 
@@ -487,7 +491,7 @@ describe("useRenderState with render options object", () => {
     unmount();
   });
 
-  it("should render success state with onSuccess option", async () => {
+  it("should render success state with renderSuccess option", async () => {
     const TestComponent = () => {
       const [renderComponent, handleData] = useRenderState<number, Error>();
 
@@ -499,10 +503,12 @@ describe("useRenderState with render options object", () => {
       }, [handleData]);
 
       return renderComponent({
-        onIdle: () => <div data-testid="status">render idle</div>,
-        onLoading: () => <div data-testid="status">render loading</div>,
-        onSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderIdle: () => <div data-testid="status">render idle</div>,
+        renderLoading: () => <div data-testid="status">render loading</div>,
+        renderSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       });
     };
 
@@ -518,7 +524,7 @@ describe("useRenderState with render options object", () => {
     unmount();
   });
 
-  it("should render error state with onError option", async () => {
+  it("should render error state with renderError option", async () => {
     const TestComponent = () => {
       const [renderComponent, handleData] = useRenderState<number, Error>();
 
@@ -529,10 +535,12 @@ describe("useRenderState with render options object", () => {
       }, [handleData]);
 
       return renderComponent({
-        onIdle: () => <div data-testid="status">render idle</div>,
-        onLoading: () => <div data-testid="status">render loading</div>,
-        onSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderIdle: () => <div data-testid="status">render idle</div>,
+        renderLoading: () => <div data-testid="status">render loading</div>,
+        renderSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       });
     };
 
@@ -554,9 +562,9 @@ describe("useRenderState with render options object", () => {
       const [renderComponent, handleData, resetData] = useRenderState<number, Error>();
 
       const renderOptions = {
-        onIdle: () => <div data-testid="status">render idle</div>,
-        onLoading: () => <div data-testid="status">render loading</div>,
-        onSuccess: (data: number) => (
+        renderIdle: () => <div data-testid="status">render idle</div>,
+        renderLoading: () => <div data-testid="status">render loading</div>,
+        renderSuccess: (data: number) => (
           <div>
             <div data-testid="status">render success: {data}</div>
             <button type="button" data-testid="reset-btn" onClick={() => resetData()}>
@@ -564,7 +572,9 @@ describe("useRenderState with render options object", () => {
             </button>
           </div>
         ),
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       };
 
       return (
@@ -644,8 +654,10 @@ describe("useRenderState with render options object", () => {
       }, [handleData]);
 
       return renderComponent({
-        onSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
-        onError: (error: unknown) => <div data-testid="status">render error {String(error)}</div>,
+        renderSuccess: (data: number) => <div data-testid="status">render success: {data}</div>,
+        renderError: (error: unknown) => (
+          <div data-testid="status">render error {String(error)}</div>
+        ),
       });
     };
 
@@ -653,7 +665,7 @@ describe("useRenderState with render options object", () => {
       return render(<TestComponent />);
     });
 
-    // Should render nothing for loading state since onLoading is not provided
+    // Should render nothing for loading state since renderLoading is not provided
     expect(screen.queryByTestId("status")).toBeNull();
 
     await act(async () => {

--- a/src/hooks/use-render-state.tsx
+++ b/src/hooks/use-render-state.tsx
@@ -7,6 +7,7 @@ import {
   RenderSuccess,
   RenderLoading,
   RenderError,
+  RenderOptions,
 } from "./use-render-state.interface";
 
 /**
@@ -119,18 +120,11 @@ const useRenderState = <Data, Error>(initialData?: Data, initialError?: Error) =
           : (args[2] as RenderSuccess<Data, Error>);
         renderError = isSingleArg ? undefined : (args[3] as RenderError<Data, Error>);
       } else {
-        const renderOptions = args[0] as
-          | {
-              onIdle?: RenderIdle<Data, Error>;
-              onLoading?: RenderLoading<Data, Error>;
-              onSuccess?: RenderSuccess<Data, Error>;
-              onError?: RenderError<Data, Error>;
-            }
-          | undefined;
-        renderIdle = renderOptions?.onIdle;
-        renderLoading = renderOptions?.onLoading;
-        renderSuccess = renderOptions?.onSuccess;
-        renderError = renderOptions?.onError;
+        const renderOptions = args[0] as RenderOptions<Data, Error> | undefined;
+        renderIdle = renderOptions?.renderIdle;
+        renderLoading = renderOptions?.renderLoading;
+        renderSuccess = renderOptions?.renderSuccess;
+        renderError = renderOptions?.renderError;
       }
 
       switch (status) {

--- a/src/hooks/use-render-state.tsx
+++ b/src/hooks/use-render-state.tsx
@@ -104,12 +104,35 @@ const useRenderState = <Data, Error>(initialData?: Data, initialError?: Error) =
   const render: Render<Data, Error> = useCallback(
     (...args) => {
       const isSingleArg = args.length === 1;
-      const renderIdle = isSingleArg ? undefined : (args[0] as RenderIdle<Data, Error>);
-      const renderLoading = isSingleArg ? undefined : (args[1] as RenderLoading<Data, Error>);
-      const renderSuccess = isSingleArg
-        ? (args[0] as RenderSuccess<Data, Error>)
-        : (args[2] as RenderSuccess<Data, Error>);
-      const renderError = isSingleArg ? undefined : (args[3] as RenderError<Data, Error>);
+      const isFunction = typeof args[0] === "function";
+
+      let renderIdle: RenderIdle<Data, Error> | undefined;
+      let renderLoading: RenderLoading<Data, Error> | undefined;
+      let renderSuccess: RenderSuccess<Data, Error> | undefined;
+      let renderError: RenderError<Data, Error> | undefined;
+
+      if (isFunction) {
+        renderIdle = isSingleArg ? undefined : (args[0] as RenderIdle<Data, Error>);
+        renderLoading = isSingleArg ? undefined : (args[1] as RenderLoading<Data, Error>);
+        renderSuccess = isSingleArg
+          ? (args[0] as RenderSuccess<Data, Error>)
+          : (args[2] as RenderSuccess<Data, Error>);
+        renderError = isSingleArg ? undefined : (args[3] as RenderError<Data, Error>);
+      } else {
+        const renderOptions = args[0] as
+          | {
+              onIdle?: RenderIdle<Data, Error>;
+              onLoading?: RenderLoading<Data, Error>;
+              onSuccess?: RenderSuccess<Data, Error>;
+              onError?: RenderError<Data, Error>;
+            }
+          | undefined;
+        renderIdle = renderOptions?.onIdle;
+        renderLoading = renderOptions?.onLoading;
+        renderSuccess = renderOptions?.onSuccess;
+        renderError = renderOptions?.onError;
+      }
+
       switch (status) {
         case Status.Idle: {
           return renderIdle?.(previousDataRef.current, previousErrorRef.current);


### PR DESCRIPTION
Added declarative render options to make `RenderState` usage more intuitive.

- Added `RenderOptions` interface to support onIdle, onLoading, onSuccess, and onError callbacks.
- Updated `render` function to accept either individual render functions or a single options object.
- Expanded test cases to cover state transitions using the new options object.